### PR TITLE
Updated sklearn to scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ joblib
 librosa
 psutil
 nltk
-sklearn
+scikit-learn
 soundfile
 resampy
 transformers


### PR DESCRIPTION
`sklearn` is now depreciated for `scikit-learn`. This fixes the failing builds.