### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-submit.yml
+++ b/.github/workflows/pre-submit.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cpuguy96/StepCOVNet/security/code-scanning/2](https://github.com/cpuguy96/StepCOVNet/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that grants only the minimal access this workflow requires. Since the workflow only reads repository contents and sends coverage to Codacy (an external service) without modifying anything on GitHub, it only needs read access to repository contents.

The best minimal change is to add a workflow‑level `permissions` block after the `on:` section. This will apply to all jobs (currently just `validation`) without needing per‑job configuration and keeps the change small and clear. We should set `contents: read`, which is equivalent to the “read‑only” default for repository contents. No imports or additional methods are needed, because this is purely a YAML configuration change within `.github/workflows/pre-submit.yml`.

Concretely, edit `.github/workflows/pre-submit.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and `jobs:` (line 9). No other lines need to be touched.
